### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -66,7 +66,7 @@ merge_protections:
     if:
       - base = main
     success_conditions:
-      - schedule = Mon-Fri 09:00-17:00[Poland/Warsaw]
+      - schedule = Mon-Fri 09:00-17:00[Europe/Warsaw]
   - name: Do not merge outdated PRs
     description: Make sure PRs are almost up to date before merging
     if:


### PR DESCRIPTION
This change has been made by @reisene from the Mergify merge protections editor.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Podsumowanie przez Sourcery

Zaktualizuj konfigurację Mergify, aby używać strefy czasowej 'Europe/Warsaw' dla ochrony scalania, zapewniając zgodność ze standardowymi konwencjami nazewnictwa stref czasowych.

CI:
- Zaktualizuj konfigurację Mergify, aby zmienić strefę czasową z 'Poland/Warsaw' na 'Europe/Warsaw' dla ochrony scalania.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the Mergify configuration to use the 'Europe/Warsaw' timezone for merge protections, ensuring consistency with standard timezone naming conventions.

CI:
- Update the Mergify configuration to change the timezone from 'Poland/Warsaw' to 'Europe/Warsaw' for merge protections.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->