### PR TITLE
fix: Improves

### DIFF
--- a/.github/workflows/label-pr-on-dispatch.yml
+++ b/.github/workflows/label-pr-on-dispatch.yml
@@ -12,14 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Add label to pull requests
         uses: actions/labeler@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Add label to all pull requests
-        run: |          
-          for pr in $(gh api /repos/${GITHUB_REPO}/pulls -q '.[] | .number'); do
-            actions/labeler@v5
-            repo-token: ${{ secrets.GITHUB_TOKEN }}        
-          done
+          pr-number: $pr

--- a/.github/workflows/label-pr-on-dispatch.yml
+++ b/.github/workflows/label-pr-on-dispatch.yml
@@ -15,4 +15,4 @@ jobs:
         uses: actions/labeler@v5
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-number: $pr
+          pr-number: ${{ github.event.pull_request.id }}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Podsumowanie przez Sourcery

Popraw odniesienie do numeru pull requesta w przepływie pracy GitHub Actions dla etykietowania pull requestów przy zdarzeniach dyspozycji.

CI:
- Napraw odniesienie do numeru pull requesta w przepływie pracy label-pr-on-dispatch, aby używać poprawnych danych zdarzenia GitHub.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct the pull request number reference in the GitHub Actions workflow for labeling pull requests on dispatch events.

CI:
- Fix the pull request number reference in the label-pr-on-dispatch workflow to use the correct GitHub event data.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->