### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -47,12 +47,6 @@ pull_request_rules:
       label:
         toggle:
           - top of the stack
-  - name: Automatic merge
-    description: Merge when PR passes all branch protection and has label automerge
-    conditions:
-      - label = automerge
-    actions:
-      merge:
   - name: Notify when a PR is removed from the queue
     description: Notify the PR author when its pull request is removed from the merge queue.
     conditions:


### PR DESCRIPTION
This change has been made by @reisene from the Mergify workflow automation editor.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Podsumowanie przez Sourcery

Zaktualizuj konfigurację Mergify, usuwając regułę automatycznego scalania, która scalała pull requesty, gdy przeszły wszystkie zabezpieczenia gałęzi i miały etykietę 'automerge'.

CI:
- Usuń regułę automatycznego scalania, która scalała pull requesty, gdy przeszły wszystkie zabezpieczenia gałęzi i miały etykietę 'automerge'.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update the Mergify configuration by removing the automatic merge rule that merged pull requests when they passed all branch protection and had the 'automerge' label.

CI:
- Remove the automatic merge rule that merged pull requests when they passed all branch protection and had the 'automerge' label.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->