### PR TITLE
Update opencommit.yml

### DIFF
--- a/.github/workflows/opencommit.yml
+++ b/.github/workflows/opencommit.yml
@@ -28,7 +28,7 @@ jobs:
           # set openAI api key in repo actions secrets,
           # for openAI keys go to: https://platform.openai.com/account/api-keys
           # for repo secret go to: <your_repo_url>/settings/secrets/actions
-          OCO_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OCO_API_KEY: ${{ secrets.OCO_API_KEY }}
 
           # customization
           OCO_TOKENS_MAX_INPUT: 4096


### PR DESCRIPTION
![TypeError: Cannot read properties of null (reading 'includes')](https://badgen.net/badge/Passed/TypeError%3A%20Cannot%20read%20properties%20of%20null%20(reading%20'includes')/red) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=reisene&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Podsumowanie przez Sourcery

Popraw odniesienie do klucza tajnego w konfiguracji przepływu pracy GitHub Actions, aby zapewnić prawidłowy dostęp do klucza API OpenAI.

CI:
- Zaktualizuj przepływ pracy GitHub Actions, aby używać poprawnego klucza tajnego dla API OpenAI, zmieniając odniesienie do tajnego klucza z OPENAI_API_KEY na OCO_API_KEY.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct the secret key reference in the GitHub Actions workflow configuration to ensure the OpenAI API key is accessed properly.

CI:
- Update the GitHub Actions workflow to use the correct secret key for the OpenAI API by changing the secret reference from OPENAI_API_KEY to OCO_API_KEY.

</details>

<!-- Generated by sourcery-ai[bot]: end summary -->