### PR TITLE
Reisene patch 1

### DIFF
--- a/.github/pr-badge.yml
+++ b/.github/pr-badge.yml
@@ -46,8 +46,9 @@
 - label: "Draft"
   message: "Draft"
   color: "lightgrey"
-  when: "$payload.pullrequest.draft"
+  when: "$payload.pull_request.draft == true"
 
 - label: "Closed"
   message: "Closed"
   color: "gray"
+  when: "$payload.pull_request.closed == true"

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -25,11 +25,21 @@ jobs:
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
+  bot-label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      
     - name: Add bot label
       uses: actions/github-script@v5
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
             github.issues.addLabel({
               issue_number: github.context.pullRequest.number,
               label: 'bot'


### PR DESCRIPTION
![reisene](https://badgen.net/badge/icon/reisene/green?label=) ![TypeError: Cannot read properties of null (reading 'includes')](https://badgen.net/badge/Passed/TypeError%3A%20Cannot%20read%20properties%20of%20null%20(reading%20'includes')/red) ![TypeError: Cannot read properties of undefined (reading 'draft')](https://badgen.net/badge/Draft/TypeError%3A%20Cannot%20read%20properties%20of%20undefined%20(reading%20'draft')/red) ![Closed](https://badgen.net/badge/Closed/Closed/gray) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=reisene&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Podsumowanie przez Sourcery

Ulepsz przepływ pracy GitHub Actions, dodając nowe zadanie do automatycznego oznaczania pull requestów etykietą 'bot' oraz naprawiając warunek w konfiguracji odznaki PR.

CI:
- Dodaj nowe zadanie 'bot-label' do przepływu pracy GitHub Actions, aby automatycznie dodawać etykietę 'bot' do pull requestów.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhance the GitHub Actions workflow by adding a new job to automatically label pull requests with 'bot' and fix a condition in the PR badge configuration.

CI:
- Add a new job 'bot-label' to the GitHub Actions workflow to automatically add a 'bot' label to pull requests.

</details>