### PR TITLE
Update label.yml

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -24,25 +24,3 @@ jobs:
       uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-
-  bot-label:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      
-    - name: Add bot label
-      uses: actions/github-script@v5
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          github.pulls.addLabel({
-          owner: github.context.repo.owner,
-          repo: github.context.repo.repo,
-          pull_number: github.context.pullRequest.number,
-          label: 'bot'
-          })

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -40,7 +40,9 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-            github.issues.addLabel({
-              issue_number: github.context.pullRequest.number,
-              label: 'bot'
-            })
+          github.pulls.addLabel({
+          owner: github.context.repo.owner,
+          repo: github.context.repo.repo,
+          pull_number: github.context.pullRequest.number,
+          label: 'bot'
+          })


### PR DESCRIPTION
![reisene](https://badgen.net/badge/icon/reisene/green?label=) ![TypeError: Cannot read properties of null (reading 'includes')](https://badgen.net/badge/Passed/TypeError%3A%20Cannot%20read%20properties%20of%20null%20(reading%20'includes')/red) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=reisene&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

## Podsumowanie przez Sourcery

Popraw przepływ pracy GitHub Actions, aby prawidłowo dodawać etykiety do pull requestów, przechodząc z API issues do API pulls.

CI:
- Napraw przepływ pracy GitHub Actions, aby poprawnie dodawać etykiety do pull requestów, używając metody 'github.pulls.addLabel' zamiast 'github.issues.addLabel'.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct the GitHub Actions workflow to properly add labels to pull requests by switching from the issues API to the pulls API.

CI:
- Fix the GitHub Actions workflow to correctly add labels to pull requests by using the 'github.pulls.addLabel' method instead of 'github.issues.addLabel'.

</details>