### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,12 @@
 pull_request_rules:
+  - name: Label Mergify Stacks PRs
+    description: Pull requests that are part of a Mergify stack should be labeled as such
+    conditions:
+      - "commits[0].commit_message ~= (?m)Change-Id:"
+    actions:
+      label:
+        toggle:
+          - stack
   - name: Automatic merge
     description: Merge when PR passes all branch protection and has label automerge
     conditions:
@@ -70,11 +78,3 @@ merge_protections:
 queue_rules: []
 merge_queue:
   max_parallel_checks: 5
-priority_rules:
-  - name: threattrix
-    priority: high
-    conditions:
-      - head = trx
-      - and:
-          - base = main
-    allow_checks_interruption: true


### PR DESCRIPTION
![reisene](https://badgen.net/badge/icon/reisene/green?label=) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=reisene&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This change has been made by @reisene from the Mergify workflow automation editor.

## Podsumowanie przez Sourcery

Usunięcie reguły priorytetu `threattrix` i dodanie etykiety dla PR-ów ze stosu Mergify.

CI:
- Oznaczanie pull requestów, które są częścią stosu Mergify etykietą.
- Usunięcie reguły wysokiego priorytetu scalania `threattrix`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove the `threattrix` priority rule and add a label for Mergify stack PRs.

CI:
- Label pull requests that are part of a Mergify stack.
- Remove the `threattrix` high priority merge rule.

</details>