### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,13 +1,4 @@
 pull_request_rules:
-  - name: Label first PR of Mergify Stacks PRs
-    description: The first PR of a Mergify stack should be labeled as such
-    conditions:
-      - "commits[0].commit_message ~= (?m)Change-Id:"
-      - -base ~= ^mergify_cli/
-    actions:
-      label:
-        toggle:
-          - top of the stack
   - name: Automatic merge during office hours + hotfix support
     description: Merge when PR passes all branch protection during office hours,
       except for hotfix


### PR DESCRIPTION
![reisene](https://badgen.net/badge/icon/reisene/green?label=) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=reisene&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This change has been made by @reisene from the Mergify workflow automation editor.

## Podsumowanie przez Sourcery

CI:
- Usunięcie automatycznego oznaczania pull requestów ze stosu Mergify.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Remove the automatic labeling of Mergify stack PRs.

</details>